### PR TITLE
[APIS-836] Fix slice length for CCI get_result_info

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -93,7 +93,7 @@ func (s *cub_stmt) bind(args []driver.Value) int {
 				C.cci_bind_param (handle, parmNum, C.CCI_A_TYPE_STR,
 					unsafe.Pointer(nil), C.CCI_U_TYPE_STRING, C.CCI_BIND_PTR);
 			default:
-				return 0
+				break
 		}
 	}
 
@@ -160,10 +160,11 @@ func (s *cub_stmt) Query(args []driver.Value) (driver.Rows, error) {
 	flag = C.char(s.flag)
 	col_info = C.cci_get_result_info(handle, &stmt_type, &col_nums)
 
+	length := int(col_nums)
 	hdr := reflect.SliceHeader {
 		Data:	uintptr(unsafe.Pointer(col_info)),
-		Len:	C.sizeof_T_CCI_COL_INFO,
-		Cap:	C.sizeof_T_CCI_COL_INFO,
+		Len:	length,
+		Cap:	length,
 	}
 
 	if C.sizeof_T_CCI_COL_INFO == C.sizeof_T_CCI_COL9x_INFO {


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-836

* The Length field of'reflect.SliceHeader' represents the length of the slice. 
* This length refers to the (maximum) **number of elements**, not the size of individual elements. For example, if we define reflect slice as follow we may have max 48 elements in the slice because the value of 'C.sizeof_T_CCI_COL_INFO' is 48

hdr := reflect.SliceHeader {
           Data:   uintptr(unsafe.Pointer(col_info)),
           Len:    C.sizeof_T_CCI_COL_INFO,
           Cap:    C.sizeof_T_CCI_COL_INFO,
}